### PR TITLE
Full qualified links issue fixed

### DIFF
--- a/spring-content-rest/complete/pom.xml
+++ b/spring-content-rest/complete/pom.xml
@@ -35,12 +35,12 @@
 		<dependency>
 			<groupId>com.github.paulcwarren</groupId>
 			<artifactId>spring-content-fs-boot-starter</artifactId>
-			<version>1.1.0.M4</version>
+			<version>1.1.0.M5-SNAPSHOT</version>
 		</dependency>
  		<dependency>
 			<groupId>com.github.paulcwarren</groupId>
 			<artifactId>spring-content-rest-boot-starter</artifactId>
-			<version>1.1.0.M4</version>
+			<version>1.1.0.M5-SNAPSHOT</version>
 		</dependency>
 		
 		<!-- Test dependencies -->

--- a/spring-content-rest/complete/src/main/java/gettingstarted/FileContentStore.java
+++ b/spring-content-rest/complete/src/main/java/gettingstarted/FileContentStore.java
@@ -4,6 +4,7 @@ import org.springframework.content.commons.repository.ContentStore;
 
 import org.springframework.content.rest.StoreRestResource;
 
-@StoreRestResource
+// linkRel = "content" so we can easily test fullyQualifiedLinks = true|false
+@StoreRestResource(linkRel = "content")
 public interface FileContentStore extends ContentStore<File, String> {
 }

--- a/spring-content-rest/complete/src/test/java/gettingstarted/FullyQualifiedLinksTests.java
+++ b/spring-content-rest/complete/src/test/java/gettingstarted/FullyQualifiedLinksTests.java
@@ -1,0 +1,10 @@
+package gettingstarted;
+
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = {
+        "spring.content.rest.fullyQualifiedLinks=true"
+})
+public class FullyQualifiedLinksTests extends GettingStartedTest {
+
+}

--- a/spring-content-rest/complete/src/test/java/gettingstarted/FullyQualifiedLinksTests.java
+++ b/spring-content-rest/complete/src/test/java/gettingstarted/FullyQualifiedLinksTests.java
@@ -1,10 +1,5 @@
 package gettingstarted;
 
-import org.springframework.test.context.TestPropertySource;
-
-@TestPropertySource(properties = {
-        "spring.content.rest.fullyQualifiedLinks=true"
-})
 public class FullyQualifiedLinksTests extends GettingStartedTest {
 
 }


### PR DESCRIPTION
Fixes the fully qualified links==false by default and the illegal state exception when accessing a content property via its fully qualified link.